### PR TITLE
Fixed angles in unary phase encoding (circuit and gate version)

### DIFF
--- a/Encoding/Unary-Encoding/UnaryEncodingGate.py
+++ b/Encoding/Unary-Encoding/UnaryEncodingGate.py
@@ -43,7 +43,7 @@ class PartialSwapGate(Gate):
         q = QuantumRegister(2)
         rule = [
                 (CnotGate(), [q[1], q[0]], []),
-                (CryGate(self.angle), [q[0], q[1]], []),
+                (CryGate(-self.angle), [q[0], q[1]], []),
                 (CnotGate(), [q[1], q[0]], [])
                 ]
         for inst in rule:
@@ -68,4 +68,4 @@ class UnaryEncodingGate(Gate):
             for step in range(middle - 1):
                 step = step + 1
                 self.definition.append((PartialSwapGate(theta[middle - 1 - step]), [distribution_qubits[middle - 1 - step], distribution_qubits[middle - step]], []))
-                self.definition.append((PartialSwapGate(theta[middle - 1 + step]), [distribution_qubits[middle - 1 + step], distribution_qubits[middle + step]], [])) 
+                self.definition.append((PartialSwapGate(-theta[middle - 1 + step]), [distribution_qubits[middle - 1 + step], distribution_qubits[middle + step]], [])) 

--- a/Encoding/Unary-Encoding/Unary_encoding.py
+++ b/Encoding/Unary-Encoding/Unary_encoding.py
@@ -14,7 +14,7 @@ def partial_swap(angle, circuit, target_qubits):
         ctrl_qubit = target_qubits[0]
         target_qubit = target_qubits[1]
         circuit.cx(target_qubit, ctrl_qubit)
-        circuit.cry(angle, ctrl_qubit, target_qubit)
+        circuit.cry(-angle, ctrl_qubit, target_qubit)
         circuit.cx(target_qubit, ctrl_qubit)
         return circuit
 
@@ -56,7 +56,7 @@ def unary_encoding(distribution, circuit = QuantumCircuit(), distribution_qubits
     for step in range(middle - 1):
         step = step + 1
         circuit = partial_swap(theta[middle - 1 - step], circuit, [distribution_qubits[middle - 1 - step], distribution_qubits[middle - step]])
-        circuit = partial_swap(theta[middle - 1 + step], circuit, [distribution_qubits[middle - 1 + step], distribution_qubits[middle + step]])
+        circuit = partial_swap(-theta[middle - 1 + step], circuit, [distribution_qubits[middle - 1 + step], distribution_qubits[middle + step]])
     return circuit, distribution_qubits
 
 
@@ -90,7 +90,7 @@ def controlled_unary_encoding(distribution, circuit, ancillae_qubits, control_qu
     for step in range(middle - 1):
         step = step + 1
         circuit = controlled_partial_swap(theta[middle - 1 - step], circuit, ancillae_qubits, control_qubits, [distribution_qubits[middle - step - 1], distribution_qubits[middle - step]])
-        circuit = controlled_partial_swap(theta[middle - 1 + step], circuit, ancillae_qubits, control_qubits, [distribution_qubits[middle + step - 1], distribution_qubits[middle + step]])
+        circuit = controlled_partial_swap(-theta[middle - 1 + step], circuit, ancillae_qubits, control_qubits, [distribution_qubits[middle + step - 1], distribution_qubits[middle + step]])
     return circuit, distribution_qubits
 
 


### PR DESCRIPTION
Fixed the unary phase encoding circuit (which previously led to erroneous minus signs in the encoded amplitude). For instance, there seems to be a typo in the description of the decomposition of the partial swap in 1912.01618.